### PR TITLE
indent margin and expose toggleExpand to context

### DIFF
--- a/projects/VirtualTree/src/tree/node.vue
+++ b/projects/VirtualTree/src/tree/node.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vir-tree-node" :style="{ paddingLeft }" @click="handleExpand">
+  <div class="vir-tree-node" :style="treeNodeStyle" @click="handleExpand">
 
     <div @click="arrowClick" :class="['node-arrow', props.expandedKeys.has(props.node.key) ? 'expanded' : '']">
       <render-icon :context="treeContext" :node="props.node" v-if="showArrow" />
@@ -44,7 +44,7 @@ import { TreeInjectionKey } from './context';
       type: Object as PropType<Set<NodeKey>>,
       required: true
     },
-    
+
     expandedKeys: {
       type: Object as PropType<Set<NodeKey>>,
       required: true
@@ -64,7 +64,11 @@ import { TreeInjectionKey } from './context';
     showCheckbox: {
       type: Boolean,
       default: false
-    }
+   },
+   indentType: {
+      type: String as PropType<("padding" | "margin")>,
+      default: "padding"
+   }
   });
 
   const showArrow = computed(() => props.node.hasChildren);
@@ -81,11 +85,14 @@ import { TreeInjectionKey } from './context';
     (e: 'checkChange', value: BaseTreeNode): void;
     (e: 'toggleExpand', value: EventParams): void;
   }>();
-  
+
   const treeContext = inject(TreeInjectionKey)!;
   const indent = 18;
-  const paddingLeft = props.node.level * indent + 'px';
-  
+
+  const treeNodeStyle = computed(() => ({
+    [`${props.indentType}Left`]: props.node.level * indent + 'px',
+  }));
+
   const titleCls = computed(() => {
       let result = 'node-title';
       if (props.selectedKeys.has(props.node.key)) {

--- a/projects/VirtualTree/src/tree/tree.vue
+++ b/projects/VirtualTree/src/tree/tree.vue
@@ -4,15 +4,15 @@
       :items="visibleList" :item-size="props.virtual?.size" key-field="key" v-slot="{ item }">
       <tree-node :node="item" :key="item.key" :show-checkbox="showCheckbox" :selected-keys="selectedKeys"
         :disabled-keys="disabledKeys" :expanded-keys="expandedKeys" :checked-keys="checkedKeys"
-        :half-checked-keys="halfCheckedKeys" @toggleExpand="toggleExpand" @selectChange="selectChange"
-        @checkChange="checkChange" />
+        :half-checked-keys="halfCheckedKeys" :indent-type="indentType" @toggleExpand="toggleExpand"
+        @selectChange="selectChange" @checkChange="checkChange" />
     </RecycleScroller>
 
     <div class="vir-tree-wrap" v-else>
       <tree-node v-for="item of visibleList" :key="item.key" :node="item" :show-checkbox="showCheckbox"
         :selected-keys="selectedKeys" :disabled-keys="disabledKeys" :expanded-keys="expandedKeys"
-        :checked-keys="checkedKeys" :half-checked-keys="halfCheckedKeys" @toggleExpand="toggleExpand"
-        @selectChange="selectChange" @checkChange="checkChange" />
+        :checked-keys="checkedKeys" :half-checked-keys="halfCheckedKeys" :indent-type="indentType"
+        @toggleExpand="toggleExpand" @selectChange="selectChange" @checkChange="checkChange" />
     </div>
   </div>
 </template>
@@ -58,6 +58,10 @@ const props = defineProps({
   checkStrictly: {
     type: Boolean,
     default: false
+  },
+  indentType: {
+    type: String as PropType<("padding" | "margin")>,
+    default: "padding"
   },
   renderNode: Function as PropType<RenderNodeFunc>,
   renderIcon: Function as PropType<RenderIconFunc>,
@@ -236,6 +240,8 @@ const context = shallowReactive({
   getSelectedNode: () => selectedNode.value,
   getCheckedNodes: () => Array.from(checkedKeys.value).map(key => key2TreeNode.value[key]).filter(Boolean), // 懒加载的情况下未必能拿到node
   getHalfCheckedNodes: () => Array.from(halfCheckedKeys.value).map(key => key2TreeNode.value[key]),
+  toggleExpand: (nodeKey: NodeKey, state?: boolean) =>
+    toggleExpand({ state: state ?? !expandedKeys.value.has(nodeKey), node: key2TreeNode.value[nodeKey] })
 });
 
 defineExpose(toRaw(context));


### PR DESCRIPTION
- add prop to change indent type to margin
- expose toggleExpand method based on nodeKey and optional state to tree context

I'm open to feedback about the impl.