### PR TITLE
add keyboard navigation (virtual focus)

### DIFF
--- a/projects/VirtualTree/src/styles/tree.css
+++ b/projects/VirtualTree/src/styles/tree.css
@@ -64,6 +64,10 @@
   background-color: var(--assist-color);
 }
 
+.vir-tree-node .node-content .node-title.focused {
+  outline: 2px solid var(--assist-color);
+}
+
 .vir-tree-node .node-content .node-title.disabled {
   cursor: not-allowed;
   color: var(--disable-color);

--- a/projects/VirtualTree/src/styles/tree.css
+++ b/projects/VirtualTree/src/styles/tree.css
@@ -5,6 +5,10 @@
   user-select: none;
 }
 
+.vir-tree:focus {
+  outline: none;
+}
+
 .vir-tree-node {
   margin: 4px 0;
   line-height: normal;

--- a/projects/VirtualTree/src/tree/node.vue
+++ b/projects/VirtualTree/src/tree/node.vue
@@ -44,7 +44,9 @@ import { TreeInjectionKey } from './context';
       type: Object as PropType<Set<NodeKey>>,
       required: true
     },
-
+    focusKey: {
+      type: [String, Number] as PropType<NodeKey>
+    },
     expandedKeys: {
       type: Object as PropType<Set<NodeKey>>,
       required: true
@@ -95,6 +97,9 @@ import { TreeInjectionKey } from './context';
 
   const titleCls = computed(() => {
       let result = 'node-title';
+      if (props.focusKey === props.node.key) {
+        result += ' focused';
+      }
       if (props.selectedKeys.has(props.node.key)) {
         result += ' selected';
       }

--- a/projects/VirtualTree/src/tree/types.ts
+++ b/projects/VirtualTree/src/tree/types.ts
@@ -27,7 +27,7 @@ type KeyNodeMap = Record<NodeKey, BaseTreeNode>;
 interface EventParams {
   state: boolean;
   node: BaseTreeNode;
-  source?: 'api' | 'click';
+  source?: 'api' | 'click' | 'key';
 }
 
 interface SelectEventParams {
@@ -37,8 +37,12 @@ interface SelectEventParams {
 
 interface FocusEventParams {
   node: BaseTreeNode | null
+}
 
-};
+interface KeydownEvent {
+  event: KeyboardEvent;
+  node: BaseTreeNode;
+}
 
 type OnKeydownFunc = (event: KeyboardEvent, node: BaseTreeNode) => void;
 type RenderNodeFunc = (node: BaseTreeNode) => JSX.Element;
@@ -81,7 +85,7 @@ export type {
   RenderNodeFunc,
   RenderIconFunc,
   LoadDataFunc,
-  OnKeydownFunc,
+  KeydownEvent,
   TreeContext,
   VirtualConfig,
 };

--- a/projects/VirtualTree/src/tree/types.ts
+++ b/projects/VirtualTree/src/tree/types.ts
@@ -35,6 +35,12 @@ interface SelectEventParams {
   node: TypeWithUndefined<BaseTreeNode>;
 }
 
+interface FocusEventParams {
+  node: BaseTreeNode | null
+
+};
+
+type OnKeydownFunc = (event: KeyboardEvent, node: BaseTreeNode) => void;
 type RenderNodeFunc = (node: BaseTreeNode) => JSX.Element;
 type RenderIconFunc = (params: {
   node: BaseTreeNode;
@@ -70,10 +76,12 @@ export type {
   TreeNodeInstance,
   KeyNodeMap,
   EventParams,
+  FocusEventParams,
   SelectEventParams,
   RenderNodeFunc,
   RenderIconFunc,
   LoadDataFunc,
+  OnKeydownFunc,
   TreeContext,
   VirtualConfig,
 };

--- a/projects/demo/package.json
+++ b/projects/demo/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ant-design/icons-vue": "^6.1.0",
     "@vitejs/plugin-vue-jsx": "^1.3.10",
-    "@ysx-libs/vue-virtual-tree": "workspace:^0.0.9",
+    "@ysx-libs/vue-virtual-tree": "workspace:*",
     "ant-design-vue": "^3.2.0",
     "highlight.js": "^11.5.1"
   }


### PR DESCRIPTION
Add a focus state of nodes to the tree. 

It does a simple style for the default items and lets you navigate the tree. It emits `focusChange` event with which the consuming component can apply styles. Via the `@keydown` event it can do other things (like open on enter).

For accessibility it is also wise to add a `aria-activedescendant` but that requires unique ids across the document which is something that needs to be managed by the app (and it can be done easily).